### PR TITLE
Remove default value for parameter followed by required parameter

### DIFF
--- a/src/Html2Text.php
+++ b/src/Html2Text.php
@@ -228,7 +228,7 @@ class Html2Text {
 		return $nextName;
 	}
 
-	static function iterateOverNode($node, $prevName = null, $in_pre = false, $is_office_document = false, $options) {
+	static function iterateOverNode($node, $prevName, $in_pre, $is_office_document, $options) {
 		if ($node instanceof \DOMText) {
 		  // Replace whitespace characters with a space (equivilant to \s)
 			if ($in_pre) {


### PR DESCRIPTION
Taken from Stadly/html2text

_Parameter with default value followed by required parameter is deprecated in PHP 8. Just removing the default values should not lead to a change in functionality. [Ref](https://www.php.net/manual/en/migration80.deprecated.php#migration80.deprecated.core)_